### PR TITLE
Run Serving HPA e2e tests

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/resources/keda.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/keda.go
@@ -79,8 +79,11 @@ func DesiredScaledObject(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscal
 				{
 					Type:       "cpu",
 					MetricType: autoscalingv2.UtilizationMetricType,
-					Metadata:   map[string]string{"value": string(int32(math.Ceil(target)))},
+					Metadata:   map[string]string{"value": fmt.Sprint(int32(math.Ceil(target)))},
 				},
+			}
+			if min <= 0 {
+				sO.Spec.MinReplicaCount = ptr.Int32(1)
 			}
 		case autoscaling.Memory:
 			memory := resource.NewQuantity(int64(target)*1024*1024, resource.BinarySI)
@@ -90,6 +93,9 @@ func DesiredScaledObject(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscal
 					MetricType: autoscalingv2.AverageValueMetricType,
 					Metadata:   map[string]string{"value": memory.String()},
 				},
+			}
+			if min <= 0 {
+				sO.Spec.MinReplicaCount = ptr.Int32(1)
 			}
 		default:
 			if target, ok := pa.Target(); ok {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HELM_BIN="/tmp/helm"
+KEDA_NS="keda"
+
+git clone https://github.com/knative/serving.git "serving"
+cd serving
+rm ./test/config/chaosduck/chaosduck.yaml
+source ./test/e2e-common.sh
+
+# disable hpa manifests
+sed -e '/SERVING_HPA_YAML/ s/^#*/#/' -i ./test/e2e-common.sh
+sed -e '/\/serving-hpa.yaml/ s/^#*/#/' -i ./test/e2e-common.sh
+sed -e '/serving hpa file/ s/^#*/#/' -i ./test/e2e-common.sh
+
+initialize --num-nodes=4 --enable-ha --cluster-version=1.28 "$@"
+
+knative_setup
+
+# Setup Helm - TODO move to the infra image
+
+wget https://get.helm.sh/helm-v3.15.2-linux-amd64.tar.gz
+tar -zxvf helm-v3.15.2-linux-amd64.tar.gz
+mv linux-amd64/helm $(HELM_BIN)
+
+# Add prometheus and KEDA helm repos
+$(HELM_BIN) repo add prometheus-community https://prometheus-community.github.io/helm-charts
+$(HELM_BIN) repo add kedacore https://kedacore.github.io/charts
+$(HELM_BIN) repo update
+
+# Install Prometheus-community
+$(HELM_BIN) install prometheus prometheus-community/kube-prometheus-stack -n default -f ../values.yaml
+kubectl wait deployment.apps/prometheus-grafana --for condition=available --timeout=600s
+kubectl wait deployment.apps/prometheus-kube-prometheus-operator --for condition=available --timeout=600s
+kubectl wait deployment.apps/prometheus-kube-state-metrics --for condition=available --timeout=600s
+
+# Install KEDA
+$(HELM_BIN) install keda kedacore/keda --namespace "${KEDA_NS}" --create-namespace
+kubectl wait deployment.apps/keda-admission-webhooks -n "${KEDA_NS}" --for condition=available --timeout=600s
+kubectl wait deployment.apps/keda-operator -n "${KEDA_NS}" --for condition=available --timeout=600s
+kubectl wait deployment.apps/keda-operator-metrics-apiserver -n "${KEDA_NS}" --for condition=available --timeout=600s
+
+#Setup Autoscaler KEDA
+ko resolve -f ../config  | sed "s/namespace: knative-serving/namespace: ${SYSTEM_NAMESPACE}/" | kubectl apply -f-
+
+# Wait for the Autoscaler KEDA deployment to be available
+kubectl wait deployments.apps/autoscaler-keda -n "${SYSTEM_NAMESPACE}" --for condition=available --timeout=600s
+
+# Run the HPA tests
+go_test_e2e -timeout=30m -tags=hpa ./test/e2e "${E2E_TEST_FLAGS[@]}" || failed=1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Runs the Serving HPA tests from the main branch. See #12 
- Minor fixes for the CPU, MEM metrics, see https://keda.sh/docs/2.14/concepts/admission-webhooks
- Tested locally:

```
--- PASS: TestHPAAutoscaleUpDownUp (440.41s)
PASS
ok  	knative.dev/serving/test/e2e	440.429s
```

On Minikube requires it ` minikube addons enable metrics-server` for CPU, MEM to work with HPA.

