### PR TITLE
Support scale to zero

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/resources/keda.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/keda.go
@@ -86,8 +86,6 @@ func DesiredScaledObject(ctx context.Context, pa *autoscalingv1alpha1.PodAutosca
 
 	if min > 0 {
 		sO.Spec.MinReplicaCount = ptr.Int32(min)
-	} else {
-		sO.Spec.MinReplicaCount = ptr.Int32(1)
 	}
 
 	if target, ok := pa.Target(); ok {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -92,7 +92,7 @@ echo ">> Uploading e2e test images..."
 ko resolve --jobs=4 -RBf ./test/test_images/metrics-test > /dev/null
 
 kubectl apply -f ./test/resources -n serving-tests
-go_test_e2e -timeout=20m -tags=e2e ./test/e2e "${E2E_TEST_FLAGS[@]}" || failed=1
+go_test_e2e -timeout=30m -tags=e2e ./test/e2e "${E2E_TEST_FLAGS[@]}" || failed=1
 
 (( failed )) && fail_test
 

--- a/test/e2e/autoscale_custom_test.go
+++ b/test/e2e/autoscale_custom_test.go
@@ -34,9 +34,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	resources2 "knative.dev/autoscaler-keda/pkg/reconciler/autoscaling/hpa/resources"
 	"knative.dev/pkg/kmap"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -56,34 +58,132 @@ const (
 )
 
 func TestUpDownCustomMetric(t *testing.T) {
-	ctx := setupCustomHPASvc(t, "http_requests_total", 5)
+	metric := "http_requests_total"
+	target := 5
+	configAnnotations := map[string]string{
+		autoscaling.ClassAnnotationKey:                    autoscaling.HPA,
+		autoscaling.MetricAnnotationKey:                   metric,
+		autoscaling.TargetAnnotationKey:                   strconv.Itoa(target),
+		autoscaling.MinScaleAnnotationKey:                 "1",
+		autoscaling.MaxScaleAnnotationKey:                 fmt.Sprintf("%d", int(maxPods)),
+		autoscaling.WindowAnnotationKey:                   "20s",
+		resources2.KedaAutoscaleAnnotationPrometheusQuery: fmt.Sprintf("sum(rate(http_requests_total{namespace='%s'}[1m]))", test.ServingFlags.TestNamespace),
+	}
+	ctx := setupCustomHPASvc(t, metric, target, configAnnotations, "")
 	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
 	assertCustomHPAAutoscaleUpToNumPods(ctx, targetPods, time.After(scaleUpTimeout), true /* quick */)
-	assertScaleDownToOne(ctx)
+	assertScaleDownToN(ctx, 1)
 	assertCustomHPAAutoscaleUpToNumPods(ctx, targetPods, time.After(scaleUpTimeout), true /* quick */)
 }
 
-func setupCustomHPASvc(t *testing.T, metric string, target int) *TestContext {
+func TestScaleToZero(t *testing.T) {
+	metric := "raw_scale"
+	target := 5
+	configAnnotations := map[string]string{
+		autoscaling.ClassAnnotationKey:                    autoscaling.HPA,
+		autoscaling.MetricAnnotationKey:                   metric,
+		autoscaling.TargetAnnotationKey:                   strconv.Itoa(target),
+		autoscaling.MinScaleAnnotationKey:                 "0",
+		autoscaling.MaxScaleAnnotationKey:                 fmt.Sprintf("%d", int(maxPods)),
+		autoscaling.WindowAnnotationKey:                   "20s",
+		resources2.KedaAutoscaleAnnotationMetricType:      string(autoscalingv2.ValueMetricType),
+		resources2.KedaAutoscaleAnnotationPrometheusQuery: fmt.Sprintf("sum by (service) (%s{namespace='%s'})", metric, test.ServingFlags.TestNamespace),
+	}
+
+	// Create a ksvc that will control another one to scale up/down via its metric values
+	configAnnotationsScale := map[string]string{
+		autoscaling.MinScaleAnnotationKey: "1",
+		autoscaling.MaxScaleAnnotationKey: "1",
+	}
+	scaleSvcName := helpers.MakeK8sNamePrefix(strings.TrimPrefix(t.Name(), "scale"))
+	ctxScale := setupSvc(t, metric, target, configAnnotationsScale, scaleSvcName)
+	test.EnsureTearDown(t, ctxScale.Clients(), ctxScale.names)
+
+	// Create a ksvc that will be scaled up/down based on a metric value set by another, mimicking external metrics
+	ctx := setupCustomHPASvcFromZero(t, metric, target, configAnnotations, "")
+	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
+
+	// Set the scale metric to 20, which should create 20/target=4 pods
+	ctxScale.names.URL.RawQuery = "scale=20"
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		ctxScale.clients.KubeClient,
+		t.Logf,
+		ctxScale.names.URL,
+		spoof.MatchesAllOf(spoof.MatchesBody("Scaling to 20")),
+		"CheckingEndpointScaleText",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, ctxScale.clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("Error probing %s: %v", ctxScale.names.URL.Hostname(), err)
+	}
+
+	// Waiting until HPA status is available, as it takes some time until HPA starts collecting metrics.
+	if err := waitForHPAReplicas(t, ctx.resources.Revision.Name, ctx.resources.Revision.Namespace, ctx.clients); err != nil {
+		t.Fatalf("Error collecting metrics by HPA: %v", err)
+	}
+
+	assertAutoscaleUpToNumPods(ctx, targetPods*2, time.After(scaleUpTimeout), true /* quick */, 0)
+
+	// Set scale metric to zero
+	ctxScale.names.URL.RawQuery = "scale=0"
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		ctxScale.clients.KubeClient,
+		t.Logf,
+		ctxScale.names.URL,
+		spoof.MatchesAllOf(spoof.MatchesBody("Scaling to 0")),
+		"CheckingEndpointScaleText",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, ctxScale.clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("Error probing %s: %v", ctxScale.names.URL.Hostname(), err)
+	}
+
+	assertScaleDownToN(ctx, 0)
+
+	// Set scale metric to 20 again, which should create 20/target=4 pods
+	ctxScale.names.URL.RawQuery = "scale=20"
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		ctxScale.clients.KubeClient,
+		t.Logf,
+		ctxScale.names.URL,
+		spoof.MatchesAllOf(spoof.MatchesBody("Scaling to 20")),
+		"CheckingEndpointScaleText",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, ctxScale.clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("Error probing %s: %v", ctxScale.names.URL.Hostname(), err)
+	}
+
+	// Waiting until HPA status is available, as it takes some time until HPA starts collecting metrics again after scale to zero.
+	// Keda de-activates the HPA if metrics is zero, so we need to wait for it to be active again.
+	if err := waitForHPAReplicas(t, ctx.resources.Revision.Name, ctx.resources.Revision.Namespace, ctx.clients); err != nil {
+		t.Fatalf("Error collecting metrics by HPA: %v", err)
+	}
+	assertAutoscaleUpToNumPods(ctx, targetPods*2, time.After(scaleUpTimeout), true /* quick */, 0)
+}
+
+func setupCustomHPASvc(t *testing.T, metric string, target int, annos map[string]string, svcName string) *TestContext {
 	t.Helper()
 	clients := test2e.Setup(t)
+	var svc string
+	if svcName != "" {
+		svc = svcName
+	} else {
+		svc = test.ObjectNameForTest(t)
+	}
 
 	t.Log("Creating a new Route and Configuration")
 	names := &test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
+		Service: svc,
 		Image:   autoscaleTestImageName,
 	}
 	resources, err := v1test.CreateServiceReady(t, clients, names,
 		[]rtesting.ServiceOption{
 			withConfigLabels(map[string]string{"metrics-test": "metrics-test"}),
-			rtesting.WithConfigAnnotations(map[string]string{
-				autoscaling.ClassAnnotationKey:                    autoscaling.HPA,
-				autoscaling.MetricAnnotationKey:                   metric,
-				autoscaling.TargetAnnotationKey:                   strconv.Itoa(target),
-				autoscaling.MinScaleAnnotationKey:                 "1",
-				autoscaling.MaxScaleAnnotationKey:                 fmt.Sprintf("%d", int(maxPods)),
-				autoscaling.WindowAnnotationKey:                   "20s",
-				resources2.KedaAutoscaleAnnotationPrometheusQuery: fmt.Sprintf("sum(rate(http_requests_total{namespace='%s'}[1m]))", test.ServingFlags.TestNamespace),
-			}), rtesting.WithResourceRequirements(corev1.ResourceRequirements{
+			rtesting.WithConfigAnnotations(annos), rtesting.WithResourceRequirements(corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("30m"),
 					corev1.ResourceMemory: resource.MustParse("20Mi"),
@@ -127,6 +227,107 @@ func setupCustomHPASvc(t *testing.T, metric string, target int) *TestContext {
 	}
 }
 
+func setupCustomHPASvcFromZero(t *testing.T, metric string, target int, annos map[string]string, svcName string) *TestContext {
+	t.Helper()
+	clients := test2e.Setup(t)
+	var svc string
+	if svcName != "" {
+		svc = svcName
+	} else {
+		svc = test.ObjectNameForTest(t)
+	}
+
+	t.Log("Creating a new Route and Configuration")
+	names := &test.ResourceNames{
+		Service: svc,
+		Image:   autoscaleTestImageName,
+	}
+	resources, err := CreateServiceReady(t, clients, names,
+		[]rtesting.ServiceOption{
+			withConfigLabels(map[string]string{"metrics-test": "metrics-test"}),
+			rtesting.WithConfigAnnotations(annos), rtesting.WithResourceRequirements(corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("30m"),
+					corev1.ResourceMemory: resource.MustParse("20Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("300m"),
+				},
+			}),
+		}...)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	return &TestContext{
+		t:         t,
+		clients:   clients,
+		names:     names,
+		resources: resources,
+		autoscaler: &AutoscalerOptions{
+			Metric: metric,
+			Target: target,
+		},
+	}
+}
+
+func setupSvc(t *testing.T, metric string, target int, annos map[string]string, svcName string) *TestContext {
+	t.Helper()
+	clients := test2e.Setup(t)
+	var svc string
+	if svcName != "" {
+		svc = svcName
+	} else {
+		svc = test.ObjectNameForTest(t)
+	}
+
+	t.Log("Creating a new Route and Configuration")
+	names := &test.ResourceNames{
+		Service: svc,
+		Image:   autoscaleTestImageName,
+	}
+	resources, err := v1test.CreateServiceReady(t, clients, names,
+		[]rtesting.ServiceOption{
+			withConfigLabels(map[string]string{"metrics-test": "metrics-test"}),
+			rtesting.WithConfigAnnotations(annos), rtesting.WithResourceRequirements(corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("30m"),
+					corev1.ResourceMemory: resource.MustParse("20Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("300m"),
+				},
+			}),
+		}...)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		names.URL,
+		spoof.MatchesAllOf(spoof.IsStatusOK),
+		"CheckingEndpointAfterCreate",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("Error probing %s: %v", names.URL.Hostname(), err)
+	}
+
+	return &TestContext{
+		t:         t,
+		clients:   clients,
+		names:     names,
+		resources: resources,
+		autoscaler: &AutoscalerOptions{
+			Metric: metric,
+			Target: target,
+		},
+	}
+}
+
 func assertCustomHPAAutoscaleUpToNumPods(ctx *TestContext, targetPods float64, done <-chan time.Time, quick bool) {
 	ctx.t.Helper()
 
@@ -146,7 +347,18 @@ func assertCustomHPAAutoscaleUpToNumPods(ctx *TestContext, targetPods float64, d
 	}
 }
 
-func assertScaleDownToOne(ctx *TestContext) {
+func assertAutoscaleUpToNumPods(ctx *TestContext, targetPods float64, done <-chan time.Time, quick bool, num float64) {
+	ctx.t.Helper()
+	var grp errgroup.Group
+	grp.Go(func() error {
+		return checkPodScale(ctx, targetPods, num, maxPods, done, quick)
+	})
+	if err := grp.Wait(); err != nil {
+		ctx.t.Fatal(err)
+	}
+}
+
+func assertScaleDownToN(ctx *TestContext, n int) {
 	deploymentName := resourcenames.Deployment(ctx.resources.Revision)
 	if err := waitForScaleToOne(ctx.t, deploymentName, ctx.clients); err != nil {
 		ctx.t.Fatalf("Unable to observe the Deployment named %s scaling down: %v", deploymentName, err)
@@ -157,7 +369,7 @@ func assertScaleDownToOne(ctx *TestContext) {
 		context.Background(),
 		ctx.clients.KubeClient,
 		func(p *corev1.PodList) (bool, error) {
-			if !(len(getDepPods(p.Items, deploymentName)) == 1) {
+			if !(len(getDepPods(p.Items, deploymentName)) == n) {
 				return false, nil
 			}
 			return true, nil
@@ -166,9 +378,9 @@ func assertScaleDownToOne(ctx *TestContext) {
 		ctx.t.Fatalf("Waiting for Pod.List to have no non-Evicted pods of %q: %v", deploymentName, err)
 	}
 
-	ctx.t.Logf("The Revision should remain ready after scaling to one.")
+	ctx.t.Logf("The Revision should remain ready after scaling to %d.", n)
 	if err := v1test.CheckRevisionState(ctx.clients.ServingClient, ctx.names.Revision, v1test.IsRevisionReady); err != nil {
-		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to one: %v", ctx.names.Revision, err)
+		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to zero: %v", ctx.names.Revision, err)
 	}
 
 	ctx.t.Logf("Scaled down.")
@@ -199,6 +411,20 @@ func waitForScaleToOne(t *testing.T, deploymentName string, clients *test.Client
 		test.ServingFlags.TestNamespace,
 		scaleToMinimumTimeout,
 	)
+}
+
+func waitForHPAReplicas(t *testing.T, name, namespace string, clients *test.Clients) error {
+	return wait.PollUntilContextTimeout(context.Background(), time.Second, 15*time.Minute, true, func(context.Context) (bool, error) {
+		hpa, err := clients.KubeClient.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if hpa.Status.CurrentMetrics == nil || hpa.Status.CurrentReplicas < 1 {
+			t.Logf("Waiting for hpa.status is available: %#v", hpa.Status)
+			return false, nil
+		}
+		return true, nil
+	})
 }
 
 func waitForHPAState(t *testing.T, name, namespace string, clients *test.Clients) error {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1serving "knative.dev/serving/pkg/apis/serving/v1"
+	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+func CreateServiceReady(t testing.TB, clients *test.Clients, names *test.ResourceNames, fopt ...rtesting.ServiceOption) (*v1test.ResourceObjects, error) {
+	if names.Image == "" {
+		return nil, fmt.Errorf("expected non-empty Image name; got Image=%v", names.Image)
+	}
+	svc, err := v1test.CreateService(t, clients, *names, fopt...)
+	if err != nil {
+		return nil, err
+	}
+	return getResourceObjects(t, clients, names, svc)
+}
+
+func getResourceObjects(t testing.TB, clients *test.Clients, names *test.ResourceNames, svc *v1serving.Service) (*v1test.ResourceObjects, error) {
+	// Populate Route and Configuration Objects with name
+	names.Route = serviceresourcenames.Route(svc)
+	names.Config = serviceresourcenames.Configuration(svc)
+	names.Revision = svc.GetName() + "-00001"
+
+	// Might have been overridden by ServiceOptions
+	names.Service = svc.Name
+
+	// Wait before getting the objects
+	time.Sleep(30 * time.Second)
+
+	t.Log("Getting latest objects Created by Service")
+	resources, err := GetResourceObjects(clients, *names)
+	if err == nil {
+		t.Log("Successfully created Service", names.Service)
+	}
+	return resources, err
+}
+
+// GetResourceObjects obtains the services resources from the k8s API server.
+func GetResourceObjects(clients *test.Clients, names test.ResourceNames) (*v1test.ResourceObjects, error) {
+	routeObject, err := clients.ServingClient.Routes.Get(context.Background(), names.Route, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	serviceObject, err := clients.ServingClient.Services.Get(context.Background(), names.Service, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	configObject, err := clients.ServingClient.Configs.Get(context.Background(), names.Config, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	revisionObject, err := clients.ServingClient.Revisions.Get(context.Background(), names.Revision, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1test.ResourceObjects{
+		Route:    routeObject,
+		Service:  serviceObject,
+		Config:   configObject,
+		Revision: revisionObject,
+	}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Allows to scale to zero based on an external metrics. KEDA de-activates hpa by setting its targets to unknown.

```
$ k get hpa -n serving-tests
NAME                           REFERENCE                                            TARGETS       MINPODS   MAXPODS   REPLICAS   AGE
scale-to-zero-gotnxmxb-00001   Deployment/scale-to-zero-gotnxmxb-00001-deployment   <unknown>/5   1         10        0          6m53s
```
Similarly the scaledobject shows to be inactive.
```
$k get scaledobject -n serving-tests
NAME                           SCALETARGETKIND      SCALETARGETNAME                           MIN   MAX   TRIGGERS     AUTHENTICATION   READY   ACTIVE   FALLBACK   PAUSED    AGE
scale-to-zero-lllzzbds-00001   apps/v1.Deployment   scale-to-zero-lllzzbds-00001-deployment         10    prometheus                    True    False    False      Unknown   6m14s
```

- Tested locally:

```
stream.go:304: I 12:57:22.399 controller-6f874b497b-jcwkt [knative.dev.serving.pkg.reconciler.gc.reconciler] [serving-tests/scale-to-zero-gotnxmxb] Reconcile succeeded
stream.go:304: I 12:57:22.399 controller-6f874b497b-jcwkt [knative.dev.serving.pkg.reconciler.configuration.Reconciler] [serving-tests/scale-to-zero-gotnxmxb] Reconcile succeeded
--- PASS: TestScaleToZero (430.80s)
PASS
ok  	knative.dev/autoscaler-keda/test/e2e	430.821s
```
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Support scale to zero.
```
